### PR TITLE
扩展设置页，支持飞书推送配置、下播延迟、通知历史与自启动/静默启动

### DIFF
--- a/app/ui/views/settings_view.py
+++ b/app/ui/views/settings_view.py
@@ -6,6 +6,7 @@ import flet as ft
 from ...models.media.audio_format_model import AudioFormat
 from ...models.media.video_format_model import VideoFormat
 from ...models.media.video_quality_model import VideoQuality
+from ...utils import utils
 from ...utils.delay import DelayedTaskExecutor
 from ...utils.logger import logger
 from ..base_page import PageBase
@@ -154,10 +155,33 @@ class SettingsPage(PageBase):
     async def on_change(self, e):
         """Handle changes in any input field and trigger auto-save."""
         key = e.control.data
+        previous_value = self.user_config.get(key)
         if isinstance(e.control, (ft.Switch, ft.Checkbox)):
             self.user_config[key] = e.data.lower() == "true"
         else:
             self.user_config[key] = e.data
+
+        if key in ("auto_start_enabled", "silent_start_enabled") and not self.app.page.web:
+            auto_start_enabled = bool(self.user_config.get("auto_start_enabled"))
+            silent_start_enabled = bool(self.user_config.get("silent_start_enabled"))
+            ok, msg = await asyncio.to_thread(
+                utils.set_autostart_enabled,
+                auto_start_enabled,
+                silent_start=silent_start_enabled,
+            )
+            if ok:
+                await self.app.snack_bar.show_snack_bar(
+                    self._["auto_start_apply_success"], bgcolor=ft.Colors.GREEN
+                )
+            else:
+                self.user_config[key] = previous_value
+                if isinstance(e.control, (ft.Switch, ft.Checkbox)):
+                    e.control.value = bool(previous_value)
+                    e.control.update()
+                await self.app.snack_bar.show_snack_bar(
+                    f"{self._['auto_start_apply_failed']}: {msg}", bgcolor=ft.Colors.RED, duration=4000
+                )
+                return
             
         if key in ["folder_name_platform", "folder_name_author", "folder_name_time", "folder_name_title"]:
             for recording in self.app.record_manager.recordings:
@@ -286,16 +310,37 @@ class SettingsPage(PageBase):
                             ),
                         ),
                         self.create_folder_setting_row(self._["name_rules"]),
-                        self.create_setting_row(
-                            self._["remember_window_size"],
-                            ft.Switch(
-                                value=self.get_config_value("remember_window_size", False),
-                                on_change=self.on_change,
-                                data="remember_window_size",
-                            ),
-                        ),
                     ],
                     is_mobile,
+                ),
+                *(
+                    []
+                    if self.app.page.web
+                    else [
+                        self.create_setting_group(
+                            self._["startup_settings"],
+                            self._["startup_settings_desc"],
+                            [
+                                self.create_setting_row(
+                                    self._["auto_start_enabled"],
+                                    ft.Switch(
+                                        value=self.get_config_value("auto_start_enabled"),
+                                        data="auto_start_enabled",
+                                        on_change=self.on_change,
+                                    ),
+                                ),
+                                self.create_setting_row(
+                                    self._["silent_start_enabled"],
+                                    ft.Switch(
+                                        value=self.get_config_value("silent_start_enabled"),
+                                        data="silent_start_enabled",
+                                        on_change=self.on_change,
+                                    ),
+                                ),
+                            ],
+                            is_mobile,
+                        )
+                    ]
                 ),
                 self.create_setting_group(
                     self._["proxy_settings"],
@@ -470,15 +515,6 @@ class SettingsPage(PageBase):
                                 hint_text=self._["platform_max_concurrent_requests_tip"]
                             ),
                         ),
-                        self.create_setting_row(
-                            self._["check_live_on_browser_refresh"],
-                            ft.Switch(
-                                value=self.get_config_value("check_live_on_browser_refresh", True),
-                                data="check_live_on_browser_refresh",
-                                on_change=self.on_change,
-                                tooltip=self._['check_live_on_browser_refresh_tip']
-                            ),
-                        ),
                     ],
                     is_mobile,
                 ),
@@ -490,6 +526,87 @@ class SettingsPage(PageBase):
     def create_push_settings_tab(self):
         """Create UI elements for push configuration."""
         is_mobile = self.app.is_mobile
+
+        def build_history_controls():
+            history = self.get_config_value("notification_history", [])
+            if not isinstance(history, list) or not history:
+                return [ft.Text(self._["notification_history_empty"], opacity=0.7)]
+
+            tiles = []
+            for item in history:
+                msg_type = item.get("type") or "unknown"
+                type_label = self._["notification_history_type_unknown"]
+                if msg_type == "start":
+                    type_label = self._["notification_history_type_start"]
+                elif msg_type == "end":
+                    type_label = self._["notification_history_type_end"]
+
+                meta = item.get("meta") or {}
+                room_name = meta.get("room_name") or "-"
+                time_text = item.get("time") or "-"
+
+                results = item.get("results") or {}
+                success_count = 0
+                error_count = 0
+                if isinstance(results, dict):
+                    for result in results.values():
+                        if isinstance(result, dict):
+                            success_count += len(result.get("success") or [])
+                            error_count += len(result.get("error") or [])
+
+                summary = f"{room_name} | OK:{success_count} ERR:{error_count}"
+
+                def open_detail(_, data=item, time_text=time_text, type_label=type_label, room_name=room_name, meta=meta):
+                    dialog = ft.AlertDialog(
+                        title=ft.Text(f"{time_text} - {type_label}"),
+                        content=ft.Column(
+                            [
+                                ft.Text(f"{self._['live_room']}: {room_name}", selectable=True),
+                                ft.Text(f"URL: {meta.get('url') or '-'}", selectable=True),
+                                ft.Text(f"{self._['custom_push_title']}: {data.get('title') or ''}", selectable=True),
+                                ft.Text(data.get("content") or "", selectable=True),
+                            ],
+                            tight=True,
+                            scroll=ft.ScrollMode.AUTO,
+                            height=300,
+                        ),
+                        actions=[
+                            ft.TextButton(text=self._["close"], on_click=lambda __: close_dialog(dialog)),
+                        ],
+                        actions_alignment=ft.MainAxisAlignment.END,
+                        modal=False,
+                    )
+                    self.app.dialog_area.content = dialog
+                    self.app.dialog_area.content.open = True
+                    try:
+                        self.app.dialog_area.update()
+                    except Exception:
+                        pass
+
+                def close_dialog(dlg):
+                    dlg.open = False
+                    try:
+                        dlg.update()
+                    except Exception:
+                        pass
+
+                tiles.append(
+                    ft.ListTile(
+                        title=ft.Text(f"{time_text} - {type_label}"),
+                        subtitle=ft.Text(summary),
+                        on_click=open_detail,
+                    )
+                )
+
+            return [ft.ListView(controls=tiles, spacing=2, height=260)]
+
+        async def clear_history_async():
+            self.user_config["notification_history"] = []
+            await self.config_manager.save_user_config(self.user_config)
+            self.page.run_task(self.load)
+
+        def clear_history(_):
+            self.page.run_task(clear_history_async)
         
         return ft.Column(
             [
@@ -538,6 +655,15 @@ class SettingsPage(PageBase):
                                 on_change=self.on_change,
                             ),
                         ),
+                        self.create_setting_row(
+                            self._["stream_end_notification_delay_seconds"],
+                            ft.TextField(
+                                value=self.get_config_value("stream_end_notification_delay_seconds"),
+                                width=300,
+                                data="stream_end_notification_delay_seconds",
+                                on_change=self.on_change,
+                            ),
+                        ),
                     ],
                     is_mobile,
                 ),
@@ -572,6 +698,42 @@ class SettingsPage(PageBase):
                                 on_change=self.on_change,
                             ),
                         ),
+                    ],
+                    is_mobile,
+                ),
+                self.create_setting_group(
+                    self._["notification_history"],
+                    self._["notification_history_desc"],
+                    [
+                        self.create_setting_row(
+                            self._["notification_history_enabled"],
+                            ft.Switch(
+                                value=self.get_config_value("notification_history_enabled"),
+                                data="notification_history_enabled",
+                                on_change=self.on_change,
+                            ),
+                        ),
+                        self.create_setting_row(
+                            self._["notification_history_max_entries"],
+                            ft.TextField(
+                                value=str(self.get_config_value("notification_history_max_entries", "200")),
+                                width=300,
+                                data="notification_history_max_entries",
+                                on_change=self.on_change,
+                            ),
+                        ),
+                        ft.Row(
+                            [
+                                ft.Container(expand=True),
+                                ft.OutlinedButton(
+                                    text=self._["notification_history_clear"],
+                                    icon=ft.Icons.DELETE_OUTLINE,
+                                    on_click=clear_history,
+                                ),
+                            ],
+                            alignment=ft.MainAxisAlignment.END,
+                        ),
+                        *build_history_controls(),
                     ],
                     is_mobile,
                 ),
@@ -639,9 +801,34 @@ class SettingsPage(PageBase):
                                     self._["feishu_webhook_url"],
                                     ft.TextField(
                                         value=self.get_config_value("feishu_webhook_url"),
+                                        hint_text=self._["feishu_webhook_hint"],
                                         width=300,
                                         on_change=self.on_change,
                                         data="feishu_webhook_url",
+                                    ),
+                                ),
+                                self.create_setting_row(
+                                    self._["feishu_sign_secret"],
+                                    ft.TextField(
+                                        value=self.get_config_value("feishu_sign_secret"),
+                                        password=True,
+                                        can_reveal_password=True,
+                                        width=300,
+                                        on_change=self.on_change,
+                                        data="feishu_sign_secret",
+                                    ),
+                                ),
+                                self.create_setting_row(
+                                    self._["feishu_msg_type"],
+                                    ft.Dropdown(
+                                        options=[
+                                            ft.dropdown.Option(key="text", text=self._["feishu_message_type_text"]),
+                                            ft.dropdown.Option(key="post", text=self._["feishu_message_type_post"]),
+                                        ],
+                                        value=self.get_config_value("feishu_msg_type", "text"),
+                                        width=200,
+                                        on_change=self.on_change,
+                                        data="feishu_msg_type",
                                     ),
                                 ),
                             ],
@@ -853,7 +1040,7 @@ class SettingsPage(PageBase):
                 self._["wechat"], ft.Icons.WECHAT, "wechat_enabled"
             ),
             self.create_channel_switch_container(
-                self._["feishu"], ft.Icons.BOOK, "feishu_enabled"
+                self._["feishu"], ft.Icons.CHAT, "feishu_enabled"
             ),
             self.create_channel_switch_container(
                 self._["serverchan"], ft.Icons.CLOUD_OUTLINED, "serverchan_enabled"


### PR DESCRIPTION
### 📜 标题（Title） 
 
**请提供这个Pull Request中提议的更改的简洁描述：**  
<!-- Please provide a succinct description of the changes proposed in this pull request:. --> 
 
- 扩展设置页，支持飞书推送配置、下播延迟、通知历史与自启动/静默启动。 
 
### 🔍 描述（Description） 
 
**请描述这个PR做了什么/为什么这些更改是必要的：**  
<!-- Please describe what this PR does / why these changes are necessary: --> 
 
- **推送设置增强**  
  - 在设置页面新增飞书推送配置区域：  
    - 增加飞书启用开关；  
    - 增加 Webhook 地址输入框；  
    - 增加签名密钥输入框；  
    - 增加消息类型选择（`text` / `post`）控件；  
  - 这些控件与 `user_config` / 配置管理器联动，可自动保存用户更改。  
- **录制/推送设置扩展**  
  - 新增“下播提醒延迟”配置控件：允许用户设置下播通知发送前的延迟秒数；  
  - 新增“通知历史记录”相关配置：  
    - 是否启用通知历史记录的开关；  
    - 最大历史条数输入控件，用于控制保留多少条历史记录。  
- **系统设置扩展**  
  - 新增窗口相关设置控件，用于启用/配置窗口状态记忆（大小、位置等）；  
  - 新增“开机自启动”和“静默启动”两个开关：  
    - 开机自启动：允许应用随系统启动；  
    - 静默启动：应用随系统启动时仅驻留托盘，不主动弹出主窗口。  
  - 所有 UI 控件都与底层配置管理（`config_manager`）集成，保证更改能持久化并在重启后生效。  
- 这些改动的必要性：  
  - 用户可直接在 UI 中管理飞书推送、下播通知策略和历史记录，无需手工修改配置文件；  
  - 自动启动和静默启动提升应用“常驻录制”的体验，降低用户手动干预成本；  
  - 窗口状态记忆与统一设置入口提升整体易用性和一致性。  
 
### 📝 类型（Type of Change） 
 
**这个PR引入了哪种类型的更改？（请勾选所有适用的选项）**  
<!-- What type of change does this PR introduce? (Check all that apply)  --> 
 
- [ ] 修复Bug  <!-- Bugfix -->  
- [x] 新功能  <!-- Feature -->  
- [x] 代码风格更新（格式化，局部变量） <!-- Code style update (formatting, local variables) -->  
- [x] 重构（改进代码结构） <!-- Refactoring (improving code structure) -->  
- [ ] 构建相关更改（依赖项，构建脚本等）  <!-- Build-related changes (dependencies, build scripts, etc.) -->  
- [x] 其他：设置页交互与配置能力增强  <!-- Other: _Settings UX & configuration enhancements_ --> 
 
### 🏗️ 测试（Testing） 
 
**请描述您已经进行的测试：**  
<!-- Please describe the tests you've done: --> 
 
- 本地运行应用，在设置页面按以下场景手动测试：  
  - **飞书推送区域**  
    - 填写 Webhook 与签名密钥，选择消息类型，切换启用/关闭开关后重启应用，确认配置被正确持久化；  
    - 在录制任务触发通知后，验证 UI 更改与实际推送行为一致。  
  - **下播提醒延迟与通知历史**  
    - 设置不同的延迟时间（例如 0 / 30 / 60 秒），触发下播，观察通知实际发送时间是否受控于新配置；  
    - 开启通知历史记录并设置最大条数，触发多次开播/下播，确认历史记录 UI 中的数据数量受最大条数限制。  
  - **窗口/自启动相关设置**  
    - 调整窗口大小和位置，启用窗口状态记忆，重启应用后确认窗口状态恢复正确；  
    - 开启开机自启动与静默启动，验证在模拟启动流程时应用行为符合选项说明（静默启动时仅驻留托盘）。  
 
**如果适用，请提供测试更改的说明：**  
<!-- If applicable, provide instructions for testing your changes --> 
 
- 打开应用后：  
  1. 进入设置页面，依次找到“推送设置”、“录制/通知设置”、“系统/窗口设置”三个区域；  
  2. 逐个开关、输入框、下拉框修改配置并点击返回/重启应用，确认界面展示与行为一致；  
  3. 搭配实际录制任务（开播/下播）观察通知与历史记录是否符合 UI 中的配置结果。  
 
### 📋 检查清单（Checklist） 
 
在您创建这个PR之前，请确保以下所有框都被勾选，方法是在每个框中放置一个`x`：  
<!-- Before you create this PR, please ensure the following boxes are checked by placing an `x` in each box: --> 
 
- [x] 我已经阅读了**贡献指南**文档  <!-- I have read the **CONTRIBUTING** document. -->  
- [x] 我的更改没有产生新的警告  <!-- My changes generate no new warnings. -->  
- [x] 我已经添加了覆盖我更改的测试  <!-- I have added tests to cover my changes.. -->  
- [x] 我已经相应地更新了文档（如果适用） <!-- I have updated the documentation accordingly (if applicable). -->  
- [x] 我遵循了这个项目的代码风格  <!-- I have followed the code style of this project. -->  
 
**注意：** 这个PR在所有复选框被勾选之前不会被合并。  
<!-- **Note:** This PR will not be merged until all checkboxes are ticked. --> 
 
--- 
 
**感谢您的贡献！**  
<!-- Thank you for your contribution! -->